### PR TITLE
Add support for keeping the Locale in the session.

### DIFF
--- a/src/main/java/edu/ksu/lti/launch/model/LtiSession.java
+++ b/src/main/java/edu/ksu/lti/launch/model/LtiSession.java
@@ -1,5 +1,7 @@
 package edu.ksu.lti.launch.model;
 
+import java.util.Locale;
+
 /**
  * Class to hold LTI session data. It is created and populated when the LTI application is first
  * launched and then stored in the session for future reference. Some commonly accessed information
@@ -14,6 +16,7 @@ public class LtiSession {
     private String eid;
     private String canvasCourseId;
     private String canvasDomain;
+    private Locale locale;
     private LtiLaunchData ltiLaunchData;
 
 
@@ -55,6 +58,14 @@ public class LtiSession {
 
     public String getCanvasDomain() {
         return canvasDomain;
+    }
+
+    public Locale getLocale() {
+        return locale;
+    }
+
+    public void setLocale(Locale locale) {
+        this.locale = locale;
     }
 
     public void setLtiLaunchData(LtiLaunchData ltiLaunchData) {

--- a/src/test/java/edu/ksu/lti/launch/spring/config/LtiLoginFilterLocaleTest.java
+++ b/src/test/java/edu/ksu/lti/launch/spring/config/LtiLoginFilterLocaleTest.java
@@ -1,0 +1,81 @@
+package edu.ksu.lti.launch.spring.config;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+import java.util.Locale;
+
+import static org.junit.Assert.*;
+
+public class LtiLoginFilterLocaleTest {
+
+    private LtiLoginFilter filter;
+
+    @Before
+    public void setUp() {
+        filter = new LtiLoginFilter(new AntPathRequestMatcher("/launch"));
+    }
+
+    @Test
+    public void testToLocaleGood() {
+        {
+            Locale fr = filter.toLocale("fr");
+            assertEquals(Locale.FRENCH, fr);
+        }
+        {
+            Locale en = filter.toLocale("en");
+            assertEquals(Locale.ENGLISH, en);
+        }
+    }
+
+    @Test
+    public void testLocaleWithCountryDash() {
+        {
+            Locale uk = filter.toLocale("en-GB");
+            assertEquals(Locale.UK, uk);
+        }
+        {
+            Locale fr = filter.toLocale("fr-FR");
+            assertEquals(Locale.FRANCE, fr);
+        }
+    }
+
+    @Test
+    public void testLocaleWithCountryUnderscore() {
+        {
+            Locale uk = filter.toLocale("en_GB");
+            assertEquals(Locale.UK, uk);
+        }
+        {
+            Locale fr = filter.toLocale("fr_FR");
+            assertEquals(Locale.FRANCE, fr);
+        }
+    }
+
+    @Test
+    public void testBadLocale() {
+        Locale def = filter.toLocale("!!!not a valid locale");
+        assertNull(def);
+    }
+
+    @Test
+    public void testUnknownLocale() {
+        Locale xx = filter.toLocale("xx_XX");
+        assertNotNull(xx);
+        assertEquals("xx", xx.getLanguage());
+        assertEquals("XX", xx.getCountry());
+    }
+
+    @Test
+    public void testEmptyLocale() {
+        Locale empty = filter.toLocale("");
+        assertNull(empty);
+    }
+
+    @Test
+    public void testNullLocale() {
+        Locale empty = filter.toLocale(null);
+        assertNull(empty);
+    }
+}


### PR DESCRIPTION
The locale in the Session can be either the one passed across on the LTI launch or null to indicate that we don’t know the locale from the LTI launch. It’s then up to the application to decide what the fallback should be.

It could at this point use the browser headers or fallback to the system default.