### PR TITLE
Better handling of bad launches.

### DIFF
--- a/src/main/java/edu/ksu/lti/launch/exception/InvalidInstanceException.java
+++ b/src/main/java/edu/ksu/lti/launch/exception/InvalidInstanceException.java
@@ -1,5 +1,7 @@
 package edu.ksu.lti.launch.exception;
 
+import org.springframework.security.core.AuthenticationException;
+
 /**
  * Thrown to indicate that this LTI application is running in an unexpected instance of Canvas.
  *
@@ -7,16 +9,31 @@ package edu.ksu.lti.launch.exception;
  * production settings are copied to the development instance and then you have a user
  * in Canvas test trying to hit the production LTI application.
  */
-public class InvalidInstanceException extends RuntimeException {
+public class InvalidInstanceException extends AuthenticationException {
     private static final long serialVersionUID = 1L;
 
-    public final String launchUrl;
+    private final String launchUrl;
+    private final String requiredUrl;
 
-    public InvalidInstanceException(String launchUrl) {
+    public InvalidInstanceException(String launchUrl, String requiredUrl) {
+        super("LTI Launch for incorrect service.");
         this.launchUrl = launchUrl;
+        this.requiredUrl = requiredUrl;
     }
 
     public String getLaunchUrl() {
         return this.launchUrl;
+    }
+
+    public String getRequiredUrl() {
+        return requiredUrl;
+    }
+
+    @Override
+    public String getMessage() {
+        return "LTI Launch was made from " +
+            launchUrl +
+            " but we are only configured to accept launches from " +
+            requiredUrl;
     }
 }

--- a/src/main/java/edu/ksu/lti/launch/oauth/LtiAuthenticationFilterEntryPoint.java
+++ b/src/main/java/edu/ksu/lti/launch/oauth/LtiAuthenticationFilterEntryPoint.java
@@ -1,0 +1,65 @@
+package edu.ksu.lti.launch.oauth;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth.provider.OAuthProcessingFilterEntryPoint;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * This is a copy of org.springframework.security.web.access.AccessDeniedHandlerImpl but adapted for a failed
+ * OAuth launch. This is because in the LTI world we are doing zero legged OAuth and just
+ * used to display a nice error to the user.
+ *
+ * @author Matthew Buckett
+ */
+public class LtiAuthenticationFilterEntryPoint extends OAuthProcessingFilterEntryPoint {
+
+    // ~ Instance fields
+    // ================================================================================================
+
+    private String errorPage;
+
+    // ~ Methods
+    // ========================================================================================================
+
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        if (!response.isCommitted()) {
+            if (errorPage != null) {
+                // Put exception into request scope (perhaps of use to a view)
+                request.setAttribute(RequestDispatcher.ERROR_STATUS_CODE, HttpStatus.FORBIDDEN.value());
+                request.setAttribute(RequestDispatcher.ERROR_EXCEPTION, authException);
+                request.setAttribute(RequestDispatcher.ERROR_REQUEST_URI, request.getRequestURI());
+                // forward to error page.
+                RequestDispatcher dispatcher = request.getRequestDispatcher(errorPage);
+                dispatcher.forward(request, response);
+            }
+            else {
+                response.sendError(HttpStatus.FORBIDDEN.value(),
+                    HttpStatus.FORBIDDEN.getReasonPhrase());
+            }
+        }
+    }
+
+    /**
+     * The error page to use. Must begin with a "/" and is interpreted relative to the
+     * current context root.
+     *
+     * @param errorPage the dispatcher path to display
+     *
+     * @throws IllegalArgumentException if the argument doesn't comply with the above
+     * limitations
+     */
+    public void setErrorPage(String errorPage) {
+        if ((errorPage != null) && !errorPage.startsWith("/")) {
+            throw new IllegalArgumentException("errorPage must begin with '/'");
+        }
+
+        this.errorPage = errorPage;
+    }
+}

--- a/src/main/java/edu/ksu/lti/launch/oauth/LtiOAuthAuthenticationHandler.java
+++ b/src/main/java/edu/ksu/lti/launch/oauth/LtiOAuthAuthenticationHandler.java
@@ -51,11 +51,7 @@ public class LtiOAuthAuthenticationHandler implements OAuthAuthenticationHandler
         if (consumer == null) {
             throw new InvalidOAuthParametersException("Failed to lookup tool consumer for: "+ key);
         }
-        // TODO This shouldn't be in the core code and should be listening for authentication events.
-        if (checkInstance) {
-            CanvasInstanceChecker checker = new CanvasInstanceChecker(consumer.getUrl(), null);
-            checker.validateInstance(request);
-        }
+
 
         LtiPrincipal principal = new LtiPrincipal(consumer, name);
 
@@ -64,6 +60,14 @@ public class LtiOAuthAuthenticationHandler implements OAuthAuthenticationHandler
         authorities.addAll(extractRoles(request.getParameter("roles")));
 
         Authentication authentication = new LtiAuthenticationToken(consumerAuthentication.getConsumerCredentials(), principal, authorities);
+
+        // TODO This shouldn't be in the core code and should be listening for authentication events.
+        // We do this after checking authentication as we will present the return URL and don't
+        // want people to be able to fake this.
+        if (checkInstance) {
+            CanvasInstanceChecker checker = new CanvasInstanceChecker(consumer.getUrl(), null);
+            checker.validateInstance(request);
+        }
         return authentication;
     }
 

--- a/src/main/java/edu/ksu/lti/launch/security/CanvasInstanceChecker.java
+++ b/src/main/java/edu/ksu/lti/launch/security/CanvasInstanceChecker.java
@@ -46,7 +46,7 @@ public class CanvasInstanceChecker {
 
     private static void validateDomain(String requestDomain, String configDomain) {
         if (configDomain != null && !configDomain.isEmpty() && requestDomain != null && !requestDomain.equalsIgnoreCase(configDomain)) {
-            throw new InvalidInstanceException(requestDomain);
+            throw new InvalidInstanceException(requestDomain, configDomain);
         }
     }
 

--- a/src/test/java/edu/ksu/lti/launch/spring/config/TestWebSecurityConfig.java
+++ b/src/test/java/edu/ksu/lti/launch/spring/config/TestWebSecurityConfig.java
@@ -20,7 +20,7 @@ public class TestWebSecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
-            .apply(new LtiConfigurer<>(toolConsumerService(), "/launch", true))
+            .apply(new LtiConfigurer<>(toolConsumerService(), "/launch", true, null))
             .and().authorizeRequests().anyRequest().hasRole("LTI_USER");
         // Disable csrf for LTI launches
         http.csrf().requireCsrfProtectionMatcher(new LtiLaunchCsrfMatcher("/launch"));


### PR DESCRIPTION
Now when you perform a cross instance launch we can optionally handle this with a nice error page. This should also mean when OAuth is incorrectly configured we can get a nice error page.