### PR TITLE
Add context to a Principal.

### DIFF
--- a/src/main/java/edu/ksu/lti/launch/oauth/LtiOAuthAuthenticationHandler.java
+++ b/src/main/java/edu/ksu/lti/launch/oauth/LtiOAuthAuthenticationHandler.java
@@ -52,8 +52,14 @@ public class LtiOAuthAuthenticationHandler implements OAuthAuthenticationHandler
             throw new InvalidOAuthParametersException("Failed to lookup tool consumer for: "+ key);
         }
 
+        String resourceId = request.getParameter("resource_id");
+        // According to the spec context_id is optional.
+        String context = request.getParameter("context_id");
+        if (context == null || context.isEmpty()) {
+            context = resourceId;
+        }
 
-        LtiPrincipal principal = new LtiPrincipal(consumer, name);
+        LtiPrincipal principal = new LtiPrincipal(consumer, name, context);
 
         HashSet<GrantedAuthority> authorities = new HashSet<>();
         authorities.add(new SimpleGrantedAuthority("ROLE_LTI_USER"));

--- a/src/main/java/edu/ksu/lti/launch/oauth/LtiPrincipal.java
+++ b/src/main/java/edu/ksu/lti/launch/oauth/LtiPrincipal.java
@@ -7,16 +7,30 @@ import java.security.Principal;
 /**
  * Holds the LTI principal. This is designed to support multitenancy.
  * While we could put all the data returned in the LTI launch in here it would make the principal rather heavy. Instead
- * we just give it enough.
+ * we just give it enough. In the future we may want to encode this as a JWT.
  */
 public class LtiPrincipal implements Principal {
 
     private final ToolConsumer consumer;
     private final String user;
+    private final String context;
 
     public LtiPrincipal(ToolConsumer consumer, String user) {
         this.consumer = consumer;
         this.user = user;
+        context = null;
+    }
+
+    /**
+     * Create a new LTI Principal.
+     * @param consumer The LTI tool consumer that this principal was authenticated through.
+     * @param user The user who was authenticated.
+     * @param context The context in the tool consumer that the user was sent from.
+     */
+    public LtiPrincipal(ToolConsumer consumer, String user, String context) {
+        this.consumer = consumer;
+        this.user = user;
+        this.context = context;
     }
 
     @Override
@@ -28,8 +42,15 @@ public class LtiPrincipal implements Principal {
         return user;
     }
 
+    /**
+     * @return This is the context that the LTI was launched from. This isn't the course ID.
+     */
+    public String getContext() {
+        return context;
+    }
+
     public ToolConsumer getConsumer() {
-        return this.getConsumer();
+        return consumer;
     }
 
     public String getTenant() {
@@ -37,6 +58,6 @@ public class LtiPrincipal implements Principal {
     }
 
     public String toString() {
-        return consumer.getInstance()+ ":"+ user;
+        return consumer.getInstance()+ ":"+ user + ((context != null)?":"+ context:"");
     }
 }

--- a/src/main/java/edu/ksu/lti/launch/service/LtiLoginService.java
+++ b/src/main/java/edu/ksu/lti/launch/service/LtiLoginService.java
@@ -21,7 +21,7 @@ public interface LtiLoginService {
 
     LtiSession getLtiSession() throws NoLtiSessionException;
 
-    void setLtiSession(LtiSession ltiSession);
+    void setLtiSession(LtiPrincipal principal, LtiSession ltiSession);
 
     /**
      * Callback that happens after a successful login. This is useful if some of the data from the LTI launch is needed

--- a/src/main/java/edu/ksu/lti/launch/service/SimpleLtiLoginService.java
+++ b/src/main/java/edu/ksu/lti/launch/service/SimpleLtiLoginService.java
@@ -32,7 +32,7 @@ public class SimpleLtiLoginService implements LtiLoginService {
     }
 
     @Override
-    public void setLtiSession(LtiSession ltiSession) {
+    public void setLtiSession(LtiPrincipal principal, LtiSession ltiSession) {
         ServletRequestAttributes sra = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
         HttpServletRequest req = sra.getRequest();
         HttpSession session = req.getSession();

--- a/src/main/java/edu/ksu/lti/launch/spring/config/LtiLoginFilter.java
+++ b/src/main/java/edu/ksu/lti/launch/spring/config/LtiLoginFilter.java
@@ -1,7 +1,6 @@
 package edu.ksu.lti.launch.spring.config;
 
 import edu.ksu.lti.launch.beans.LtiLaunchPropertyValues;
-import edu.ksu.lti.launch.beans.SnakeCasePropertyValues;
 import edu.ksu.lti.launch.model.LtiLaunchData;
 import edu.ksu.lti.launch.model.LtiSession;
 import edu.ksu.lti.launch.oauth.LtiPrincipal;
@@ -13,7 +12,6 @@ import org.springframework.beans.PropertyValues;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.FilterChainProxy;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.validation.DataBinder;
 
@@ -78,7 +76,7 @@ public class LtiLoginFilter implements Filter {
                 Locale locale = toLocale(launchData.getLaunchPresentationLocale());
                 ltiSession.setLocale(locale);
                 ltiSession.setLtiLaunchData(launchData);
-                ltiLoginService.setLtiSession(ltiSession);
+                ltiLoginService.setLtiSession((LtiPrincipal) principal, ltiSession);
                 String view = ltiLoginService.getInitialView((LtiPrincipal) principal);
 
                 // Set the view afterwards as getting the initial view may need the LtiSession


### PR DESCRIPTION
This means that a principal launched from one context isn’t the same as one launched from another context. This is useful so that a user who has roles in one LTI launch is seen as different from the same user who has different roles in a different context.