### PR TITLE
Just try to stop launch data from being null.

### DIFF
--- a/src/main/java/edu/ksu/lti/launch/model/LtiSession.java
+++ b/src/main/java/edu/ksu/lti/launch/model/LtiSession.java
@@ -1,6 +1,7 @@
 package edu.ksu.lti.launch.model;
 
 import java.util.Locale;
+import java.util.Objects;
 
 /**
  * Class to hold LTI session data. It is created and populated when the LTI application is first
@@ -19,8 +20,16 @@ public class LtiSession {
     private Locale locale;
     private LtiLaunchData ltiLaunchData;
 
+    public LtiSession(LtiLaunchData launchData) {
+        Objects.requireNonNull(launchData, "launchData cannot be null");
+        this.ltiLaunchData = launchData;
+    }
 
-	public void setApplicationName(String applicationName) {
+    public LtiSession() {
+        this.ltiLaunchData = new LtiLaunchData();
+    }
+
+    public void setApplicationName(String applicationName) {
         this.applicationName = applicationName;
     }
 

--- a/src/main/java/edu/ksu/lti/launch/spring/config/LtiLoginFilter.java
+++ b/src/main/java/edu/ksu/lti/launch/spring/config/LtiLoginFilter.java
@@ -68,7 +68,7 @@ public class LtiLoginFilter implements Filter {
                 LtiLaunchData launchData = new LtiLaunchData();
                 DataBinder dataBinder = new DataBinder(launchData);
                 dataBinder.bind(propertyValues);
-                LtiSession ltiSession = new LtiSession();
+                LtiSession ltiSession = new LtiSession(launchData);
                 ltiSession.setApplicationName(((LtiPrincipal) principal).getTenant());
                 ltiSession.setCanvasCourseId(launchData.getCustom().get("canvas_course_id"));
                 ltiSession.setCanvasDomain(launchData.getCustom().get("canvas_api_domain"));


### PR DESCRIPTION
When Spring autocreates an instance of LtiSession we should have an empty launch data rather than a null one. The allows for less null checks in calling code.

It doesn’t stop someone from explicitly setting launch data to null but makes it harder to accidentally end up with it being null.