### PR TITLE
Roles should always be prefixed with ROLE_

### DIFF
--- a/src/main/java/edu/ksu/lti/launch/oauth/CustomLtiUserAuthority.java
+++ b/src/main/java/edu/ksu/lti/launch/oauth/CustomLtiUserAuthority.java
@@ -16,7 +16,7 @@ public class CustomLtiUserAuthority implements LtiUserAuthority {
 
     @Override
     public String getAuthority() {
-        return role;
+        return ROLE_PREFIX + role;
     }
 
     @Override

--- a/src/main/java/edu/ksu/lti/launch/oauth/LtiUserAuthority.java
+++ b/src/main/java/edu/ksu/lti/launch/oauth/LtiUserAuthority.java
@@ -4,6 +4,8 @@ import org.springframework.security.core.GrantedAuthority;
 
 public interface LtiUserAuthority extends GrantedAuthority {
 
+    String ROLE_PREFIX = "ROLE_";
+
     /**
      * @return <code>true</code> if this role is outside the standard LTI roles.
      */

--- a/src/main/java/edu/ksu/lti/launch/oauth/StandardLtiUserAuthority.java
+++ b/src/main/java/edu/ksu/lti/launch/oauth/StandardLtiUserAuthority.java
@@ -17,7 +17,7 @@ public class StandardLtiUserAuthority implements LtiUserAuthority {
 
     @Override
     public String getAuthority() {
-        return role.toString();
+        return ROLE_PREFIX + role.toString();
     }
 
     @Override


### PR DESCRIPTION
This allows them to work with Spring Security without any changes. This is because Spring Security always assumes that roles begin with ROLE_.