### PR TITLE
Support for LTI validation

### DIFF
--- a/src/main/java/edu/ksu/lti/launch/oauth/InvalidLtiLaunchException.java
+++ b/src/main/java/edu/ksu/lti/launch/oauth/InvalidLtiLaunchException.java
@@ -1,0 +1,30 @@
+package edu.ksu.lti.launch.oauth;
+
+import org.springframework.security.core.AuthenticationException;
+
+/**
+ * An exception with the LTI for which we should redirect to the Tool Consumer and include a nice error message.
+ */
+public class InvalidLtiLaunchException extends AuthenticationException {
+
+    private final String returnUrl;
+
+    /**
+     * Create a new launch failure.
+     * @param s The error message to display to the user.
+     * @param returnUrl The tool consumer URL to send the response back to, may be {@code null}
+     */
+    public InvalidLtiLaunchException(String s, String returnUrl) {
+        super(s);
+        this.returnUrl = returnUrl;
+    }
+
+    public String getReturnUrl() {
+        return returnUrl;
+    }
+
+    public boolean hasReturnUrl() {
+        return returnUrl != null && !returnUrl.isEmpty();
+    }
+
+}

--- a/src/main/java/edu/ksu/lti/launch/oauth/LtiOAuthAuthenticationHandler.java
+++ b/src/main/java/edu/ksu/lti/launch/oauth/LtiOAuthAuthenticationHandler.java
@@ -76,7 +76,11 @@ public class LtiOAuthAuthenticationHandler implements OAuthAuthenticationHandler
         // We do this after checking authentication as we will present the return URL and don't
         // want people to be able to fake this.
         if (checkInstance) {
-            CanvasInstanceChecker checker = new CanvasInstanceChecker(consumer.getUrl(), null);
+            String consumerUrl = consumer.getUrl();
+            if (consumerUrl == null || consumerUrl.isEmpty()) {
+                throw new IllegalArgumentException("Not URL set on "+ key+ " but we are set to check instances.");
+            }
+            CanvasInstanceChecker checker = new CanvasInstanceChecker(consumerUrl, null);
             checker.validateInstance(request);
         }
         return authentication;

--- a/src/main/java/edu/ksu/lti/launch/security/CanvasInstanceChecker.java
+++ b/src/main/java/edu/ksu/lti/launch/security/CanvasInstanceChecker.java
@@ -3,6 +3,7 @@ package edu.ksu.lti.launch.security;
 import edu.ksu.lti.launch.exception.InvalidInstanceException;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.Objects;
 
 /**
  * Checks which Canvas instance this application is running in.
@@ -22,6 +23,7 @@ public class CanvasInstanceChecker {
     private final String secondCanvasUrl;
 
     public CanvasInstanceChecker(String canvasUrl, String secondCanvasUrl) {
+        Objects.requireNonNull(canvasUrl, "canvasUrl cannot be null");
         this.canvasUrl = canvasUrl;
         this.secondCanvasUrl = secondCanvasUrl;
     }

--- a/src/main/java/edu/ksu/lti/launch/service/SimpleToolConsumer.java
+++ b/src/main/java/edu/ksu/lti/launch/service/SimpleToolConsumer.java
@@ -13,10 +13,14 @@ public class SimpleToolConsumer implements ToolConsumer {
     private final String name;
     private final String url;
 
+    /**
+     * @param instance The instance, this is a unique key for the tool consumer.
+     * @param name A nice display name for the instance.
+     * @param url The URL for the instance, can be null.
+     */
     public SimpleToolConsumer(String instance, String name, String url) {
         requireNonNull(instance, "The instance cannot be null.");
         requireNonNull(name, "The name cannot be null.");
-        requireNonNull(url, "The url cannot be null.");
         this.instance = instance;
         this.name = name;
         this.url = url;

--- a/src/main/java/edu/ksu/lti/launch/service/SingleToolConsumerService.java
+++ b/src/main/java/edu/ksu/lti/launch/service/SingleToolConsumerService.java
@@ -1,5 +1,7 @@
 package edu.ksu.lti.launch.service;
 
+import java.util.Objects;
+
 /**
  * This just handles one tool consumer.
  */
@@ -10,6 +12,7 @@ public class SingleToolConsumerService implements ToolConsumerService {
 
     public SingleToolConsumerService(String instance, String name, String url, String secret) {
         this.toolConsumer = new SimpleToolConsumer(instance, name, url);
+        Objects.requireNonNull(secret, "secret cannot be null.");
         this.secret = secret;
     }
 

--- a/src/main/java/edu/ksu/lti/launch/spring/config/LtiConfigurer.java
+++ b/src/main/java/edu/ksu/lti/launch/spring/config/LtiConfigurer.java
@@ -40,9 +40,10 @@ public class LtiConfigurer<B extends HttpSecurityBuilder<B>> extends SecurityCon
      * @param checkInstance If <code>true</code> the check the instance we launched from matches the one we are configured for.
      * @param errorPath Path to redirect errors to, if <code>null</code> then just return status codes.
      */
-    public LtiConfigurer(ToolConsumerService toolConsumerService, String path, boolean checkInstance, String errorPath) {
+    public LtiConfigurer(ToolConsumerService toolConsumerService, String path, boolean checkInstance, boolean validateLti, String errorPath) {
         this.oauthAuthenticationHandler = new LtiOAuthAuthenticationHandler(toolConsumerService);
         this.oauthAuthenticationHandler.setCheckInstance(checkInstance);
+        this.oauthAuthenticationHandler.setValidateLti(validateLti);
         this.oauthConsumerDetailsService = new LtiConsumerDetailsService(toolConsumerService);
         this.path = path;
         LtiAuthenticationFilterEntryPoint entryPoint = new LtiAuthenticationFilterEntryPoint();

--- a/src/test/java/edu/ksu/lti/launch/spring/config/LtiLoginFilterLocaleTest.java
+++ b/src/test/java/edu/ksu/lti/launch/spring/config/LtiLoginFilterLocaleTest.java
@@ -8,6 +8,9 @@ import java.util.Locale;
 
 import static org.junit.Assert.*;
 
+/**
+ * This tests the extracting of the Locale from the LTI launch.
+ */
 public class LtiLoginFilterLocaleTest {
 
     private LtiLoginFilter filter;

--- a/src/test/java/edu/ksu/lti/launch/spring/config/TestWebSecurityConfig.java
+++ b/src/test/java/edu/ksu/lti/launch/spring/config/TestWebSecurityConfig.java
@@ -7,6 +7,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.oauth.provider.nonce.NullNonceServices;
+import org.springframework.security.oauth.provider.nonce.OAuthNonceServices;
 
 @Configuration
 @EnableWebSecurity(debug = false)
@@ -15,6 +17,11 @@ public class TestWebSecurityConfig extends WebSecurityConfigurerAdapter {
     @Bean
     public ToolConsumerService toolConsumerService() {
         return new SingleToolConsumerService("test", "Test", "http://localhost", "secret");
+    }
+
+    @Bean
+    public OAuthNonceServices oAuthNonceServices() {
+        return new NullNonceServices();
     }
 
     @Override

--- a/src/test/java/edu/ksu/lti/launch/test/LtiSigning.java
+++ b/src/test/java/edu/ksu/lti/launch/test/LtiSigning.java
@@ -1,0 +1,36 @@
+package edu.ksu.lti.launch.test;
+
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class LtiSigning {
+
+    static Map<String, List<String>> toQueryParams(String encodedQueryString) {
+        MultiValueMap<String, String> queryParams = UriComponentsBuilder
+            .fromUriString("?" + encodedQueryString)
+            .build()
+            .getQueryParams();
+        return queryParams.entrySet()
+            .stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue()
+                .stream()
+                .map(s -> UriUtils.decode(s, "UTF-8"))
+                .collect(Collectors.toList()))
+            );
+    }
+
+    static Map<String, String> getRequiredLtiParameters() {
+        Map<String, String> additional = new HashMap<>();
+        additional.put("lti_version", "LTI-1p0");
+        additional.put("resource_link_id", "resourceLinkId");
+        additional.put("lti_message_type", "basic-lti-launch-request");
+        additional.put("launch_presentation_return_url", "http://tool.consumer/return");
+        return additional;
+    }
+}

--- a/src/test/java/edu/ksu/lti/launch/test/LtiStandardsITest.java
+++ b/src/test/java/edu/ksu/lti/launch/test/LtiStandardsITest.java
@@ -1,0 +1,197 @@
+package edu.ksu.lti.launch.test;
+
+
+import edu.ksu.lti.launch.service.SingleToolConsumerService;
+import edu.ksu.lti.launch.service.ToolConsumerService;
+import edu.ksu.lti.launch.spring.config.LtiConfigurer;
+import edu.ksu.lti.launch.spring.config.LtiLaunchCsrfMatcher;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.oauth.common.signature.SharedConsumerSecretImpl;
+import org.springframework.security.oauth.consumer.BaseProtectedResourceDetails;
+import org.springframework.security.oauth.consumer.OAuthConsumerSupport;
+import org.springframework.security.oauth.consumer.client.CoreOAuthConsumerSupport;
+import org.springframework.security.oauth.provider.nonce.NullNonceServices;
+import org.springframework.security.oauth.provider.nonce.OAuthNonceServices;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
+import static edu.ksu.lti.launch.test.LtiSigning.getRequiredLtiParameters;
+import static edu.ksu.lti.launch.test.LtiSigning.toQueryParams;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/*
+ * This checks that you can use the library without supplying a URL for the SingleToolConsumerService.
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+public class LtiStandardsITest {
+
+    private URL url;
+    private BaseProtectedResourceDetails details;
+    private OAuthConsumerSupport support;
+    private MockMvc mockMvc;
+    @Autowired
+    private WebApplicationContext wac;
+
+    @Before
+    public void setup() throws MalformedURLException {
+        support = new CoreOAuthConsumerSupport();
+        details = new BaseProtectedResourceDetails();
+        details.setAcceptsAuthorizationHeader(false);
+        details.setSharedSecret(new SharedConsumerSecretImpl("secret"));
+        details.setConsumerKey("test");
+        url = new URL("http://server/launch");
+
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
+            .apply(SecurityMockMvcConfigurers.springSecurity())
+            .build();
+    }
+
+    @Test
+    public void testNoResourceLinkId() throws Exception {
+        Map<String, String> requiredLtiParameters = getRequiredLtiParameters();
+        requiredLtiParameters.remove("resource_link_id");
+        String encodedQueryString = support.getOAuthQueryString(details, null, url, "POST", requiredLtiParameters);
+
+        Map<String, List<String>> collect = toQueryParams(encodedQueryString);
+
+        this.mockMvc.perform(post("http://server/launch")
+            .params(new LinkedMultiValueMap<>(collect))
+            .accept(MediaType.TEXT_HTML))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(result -> result.getResponse().getRedirectedUrl().startsWith("http://tool.consumer/"));
+    }
+
+    @Test
+    public void testNoResourceLinkIdNoReturn() throws Exception {
+        Map<String, String> requiredLtiParameters = getRequiredLtiParameters();
+        requiredLtiParameters.remove("resource_link_id");
+        requiredLtiParameters.remove("launch_presentation_return_url");
+        String encodedQueryString = support.getOAuthQueryString(details, null, url, "POST", requiredLtiParameters);
+
+        Map<String, List<String>> collect = toQueryParams(encodedQueryString);
+
+        this.mockMvc.perform(post("http://server/launch")
+            .params(new LinkedMultiValueMap<>(collect))
+            .accept(MediaType.TEXT_HTML))
+            .andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    public void testInvalidLtiVersion() throws Exception {
+        Map<String, String> requiredLtiParameters = getRequiredLtiParameters();
+        requiredLtiParameters.put("lti_version", "LTI-1");
+        String encodedQueryString = support.getOAuthQueryString(details, null, url, "POST", requiredLtiParameters);
+
+        Map<String, List<String>> collect = toQueryParams(encodedQueryString);
+
+        this.mockMvc.perform(post("http://server/launch")
+            .params(new LinkedMultiValueMap<>(collect))
+            .accept(MediaType.TEXT_HTML))
+            .andExpect(result -> result.getResponse().getRedirectedUrl().startsWith("http://tool.consumer/"));
+    }
+
+    @Test
+    public void testWrongLtiVersion() throws Exception {
+        Map<String, String> requiredLtiParameters = getRequiredLtiParameters();
+        requiredLtiParameters.put("lti_version", "LTI-2");
+        String encodedQueryString = support.getOAuthQueryString(details, null, url, "POST", requiredLtiParameters);
+
+        Map<String, List<String>> collect = toQueryParams(encodedQueryString);
+
+        this.mockMvc.perform(post("http://server/launch")
+            .params(new LinkedMultiValueMap<>(collect))
+            .accept(MediaType.TEXT_HTML))
+            .andExpect(result -> result.getResponse().getRedirectedUrl().startsWith("http://tool.consumer/"));
+    }
+
+    @Test
+    public void testMissingLtiVersion() throws Exception {
+
+        Map<String, String> requiredLtiParameters = getRequiredLtiParameters();
+        requiredLtiParameters.remove("lti_version");
+        String encodedQueryString = support.getOAuthQueryString(details, null, url, "POST", requiredLtiParameters);
+
+        Map<String, List<String>> collect = toQueryParams(encodedQueryString);
+
+        this.mockMvc.perform(post("http://server/launch")
+            .params(new LinkedMultiValueMap<>(collect))
+            .accept(MediaType.TEXT_HTML))
+            .andExpect(result -> result.getResponse().getRedirectedUrl().startsWith("http://tool.consumer/"));
+    }
+
+    @Test
+    public void testInvalidLtiMessageType() throws Exception {
+        Map<String, String> requiredLtiParameters = getRequiredLtiParameters();
+        requiredLtiParameters.put("lti_message_type", "not-a-valid-type");
+        String encodedQueryString = support.getOAuthQueryString(details, null, url, "POST", requiredLtiParameters);
+
+        Map<String, List<String>> collect = toQueryParams(encodedQueryString);
+
+        this.mockMvc.perform(post("http://server/launch")
+            .params(new LinkedMultiValueMap<>(collect))
+            .accept(MediaType.TEXT_HTML))
+            .andExpect(result -> result.getResponse().getRedirectedUrl().startsWith("http://tool.consumer/"));
+    }
+
+    @Test
+    public void testMissingLtiMessageType() throws Exception {
+        Map<String, String> requiredLtiParameters = getRequiredLtiParameters();
+        requiredLtiParameters.remove("lti_message_type");
+        String encodedQueryString = support.getOAuthQueryString(details, null, url, "POST", requiredLtiParameters);
+
+        Map<String, List<String>> collect = toQueryParams(encodedQueryString);
+
+        this.mockMvc.perform(post("http://server/launch")
+            .params(new LinkedMultiValueMap<>(collect))
+            .accept(MediaType.TEXT_HTML))
+            .andExpect(result -> result.getResponse().getRedirectedUrl().startsWith("http://tool.consumer/"));
+    }
+
+    @Configuration
+    @EnableWebSecurity
+    public static class TestWebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+        @Bean
+        public ToolConsumerService toolConsumerService() {
+            // We don't have a URL for the service here.
+            return new SingleToolConsumerService("test", "Test", null, "secret");
+        }
+
+        @Bean
+        public OAuthNonceServices oAuthNonceServices() {
+            return new NullNonceServices();
+        }
+
+        @Override
+        protected void configure(HttpSecurity http) throws Exception {
+            http
+                // We don't enable instance checking.
+                .apply(new LtiConfigurer<>(toolConsumerService(), "/launch", false, true, null))
+                .and().authorizeRequests().anyRequest().hasRole("LTI_USER");
+            // Disable csrf for LTI launches
+            http.csrf().requireCsrfProtectionMatcher(new LtiLaunchCsrfMatcher("/launch"));
+        }
+    }
+
+}

--- a/src/test/java/edu/ksu/lti/launch/test/NoUrlITest.java
+++ b/src/test/java/edu/ksu/lti/launch/test/NoUrlITest.java
@@ -1,0 +1,127 @@
+package edu.ksu.lti.launch.test;
+
+
+import edu.ksu.lti.launch.service.SingleToolConsumerService;
+import edu.ksu.lti.launch.service.ToolConsumerService;
+import edu.ksu.lti.launch.spring.config.LtiConfigurer;
+import edu.ksu.lti.launch.spring.config.LtiLaunchCsrfMatcher;
+import edu.ksu.lti.launch.spring.config.TestWebSecurityConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.oauth.common.signature.SharedConsumerSecretImpl;
+import org.springframework.security.oauth.consumer.BaseProtectedResourceDetails;
+import org.springframework.security.oauth.consumer.OAuthConsumerSupport;
+import org.springframework.security.oauth.consumer.client.CoreOAuthConsumerSupport;
+import org.springframework.security.oauth.provider.nonce.NullNonceServices;
+import org.springframework.security.oauth.provider.nonce.OAuthNonceServices;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/*
+ * This checks that you can use the library without supplying a URL for the SingleToolConsumerService.
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+public class NoUrlITest {
+
+    @Configuration
+    @EnableWebSecurity
+    public static class TestWebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+        @Bean
+        public ToolConsumerService toolConsumerService() {
+            // We don't have a URL for the service here.
+            return new SingleToolConsumerService("test", "Test", null, "secret");
+        }
+
+        @Bean
+        public OAuthNonceServices oAuthNonceServices() {
+            return new NullNonceServices();
+        }
+
+        @Override
+        protected void configure(HttpSecurity http) throws Exception {
+            http
+                // We don't enable instance checking.
+                .apply(new LtiConfigurer<>(toolConsumerService(), "/launch", false, null))
+                .and().authorizeRequests().anyRequest().hasRole("LTI_USER");
+            // Disable csrf for LTI launches
+            http.csrf().requireCsrfProtectionMatcher(new LtiLaunchCsrfMatcher("/launch"));
+        }
+    }
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    @Before
+    public void setup() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(wac)
+            .apply(SecurityMockMvcConfigurers.springSecurity())
+            .build();
+    }
+
+    @Test
+    public void testSignedLogin() throws Exception {
+        OAuthConsumerSupport support = new CoreOAuthConsumerSupport();
+        BaseProtectedResourceDetails details = new BaseProtectedResourceDetails();
+        details.setAcceptsAuthorizationHeader(false);
+        details.setSharedSecret(new SharedConsumerSecretImpl("secret"));
+        details.setConsumerKey("test");
+        URL url = new URL("http://server/launch");
+        // There isn't a nice way to get the signed values back from the library.
+        String encodedQueryString = support.getOAuthQueryString(details, null, url, "POST", Collections.emptyMap());
+
+        Map<String, List<String>> collect = toQueryParams(encodedQueryString);
+
+        this.mockMvc.perform(post("http://server/launch")
+            .params(new LinkedMultiValueMap<>(collect))
+            .accept(MediaType.TEXT_HTML))
+            .andExpect(status().is3xxRedirection());
+    }
+
+
+    private Map<String, List<String>> toQueryParams(String encodedQueryString) {
+        MultiValueMap<String, String> queryParams = UriComponentsBuilder
+            .fromUriString("?" + encodedQueryString)
+            .build()
+            .getQueryParams();
+        return queryParams.entrySet()
+            .stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue()
+                .stream()
+                .map(s -> UriUtils.decode(s, "UTF-8"))
+                .collect(Collectors.toList()))
+            );
+    }
+
+}

--- a/src/test/java/edu/ksu/lti/launch/test/SpringContextITest.java
+++ b/src/test/java/edu/ksu/lti/launch/test/SpringContextITest.java
@@ -1,7 +1,6 @@
 package edu.ksu.lti.launch.test;
 
 
-import edu.ksu.lti.launch.exception.InvalidInstanceException;
 import edu.ksu.lti.launch.spring.config.TestWebSecurityConfig;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/edu/ksu/lti/launch/test/TestWebSecurityConfig.java
+++ b/src/test/java/edu/ksu/lti/launch/test/TestWebSecurityConfig.java
@@ -1,7 +1,9 @@
-package edu.ksu.lti.launch.spring.config;
+package edu.ksu.lti.launch.test;
 
 import edu.ksu.lti.launch.service.SingleToolConsumerService;
 import edu.ksu.lti.launch.service.ToolConsumerService;
+import edu.ksu.lti.launch.spring.config.LtiConfigurer;
+import edu.ksu.lti.launch.spring.config.LtiLaunchCsrfMatcher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -16,7 +18,7 @@ public class TestWebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Bean
     public ToolConsumerService toolConsumerService() {
-        return new SingleToolConsumerService("test", "Test", "http://localhost", "secret");
+        return new SingleToolConsumerService("test", "Test", "http://tool.consumer/", "secret");
     }
 
     @Bean
@@ -27,7 +29,7 @@ public class TestWebSecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
-            .apply(new LtiConfigurer<>(toolConsumerService(), "/launch", true, null))
+            .apply(new LtiConfigurer<>(toolConsumerService(), "/launch", true, true, null))
             .and().authorizeRequests().anyRequest().hasRole("LTI_USER");
         // Disable csrf for LTI launches
         http.csrf().requireCsrfProtectionMatcher(new LtiLaunchCsrfMatcher("/launch"));


### PR DESCRIPTION
This adds better validation of an LTI launch. It checks that the required parameters and send and gets any code using this library closer to passing the LTI validation.

#12 needs merging before this.