### PR TITLE
Allow library to work when not deployed at root.

### DIFF
--- a/lti-launch-core/src/main/java/edu/ksu/lti/launch/service/LtiLoginService.java
+++ b/lti-launch-core/src/main/java/edu/ksu/lti/launch/service/LtiLoginService.java
@@ -6,6 +6,8 @@ import edu.ksu.lti.launch.model.LtiSession;
 import edu.ksu.lti.launch.oauth.LtiPrincipal;
 import org.springframework.context.ApplicationListener;
 
+import javax.servlet.http.HttpServletRequest;
+
 /**
  * Users of this library should implement this interface if they want custom behaviour.
  * @see SimpleLtiLoginService
@@ -17,7 +19,7 @@ public interface LtiLoginService {
      * @param principal The authenticated principal.
      * @return The URL to redirect to.
      */
-    String getInitialView(LtiPrincipal principal);
+    String getInitialView(HttpServletRequest request, LtiPrincipal principal);
 
     LtiSession getLtiSession() throws NoLtiSessionException;
 

--- a/lti-launch-core/src/main/java/edu/ksu/lti/launch/service/SimpleLtiLoginService.java
+++ b/lti-launch-core/src/main/java/edu/ksu/lti/launch/service/SimpleLtiLoginService.java
@@ -15,8 +15,8 @@ import javax.servlet.http.HttpSession;
 public class SimpleLtiLoginService implements LtiLoginService {
 
     @Override
-    public String getInitialView(LtiPrincipal principal) {
-        return "/";
+    public String getInitialView(HttpServletRequest httpServletRequest, LtiPrincipal principal) {
+        return httpServletRequest.getContextPath()+ "/";
     }
 
     @Override

--- a/lti-launch-core/src/main/java/edu/ksu/lti/launch/spring/config/LtiLoginFilter.java
+++ b/lti-launch-core/src/main/java/edu/ksu/lti/launch/spring/config/LtiLoginFilter.java
@@ -81,7 +81,7 @@ public class LtiLoginFilter implements Filter {
                 ltiSession.setLocale(locale);
                 ltiSession.setLtiLaunchData(launchData);
                 ltiLoginService.setLtiSession((LtiPrincipal) principal, ltiSession);
-                String view = ltiLoginService.getInitialView((LtiPrincipal) principal);
+                String view = ltiLoginService.getInitialView(request, (LtiPrincipal) principal);
 
                 // Set the view afterwards as getting the initial view may need the LtiSession
                 ltiSession.setInitialViewPath(view);


### PR DESCRIPTION
The final redirect was always take to to be relative to the root, this prevents the webapp from being easily deployed anywhere apart from the webapp root.