### PR TITLE
Relocate to the Centre for Teaching and Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ LTI Launch is a project designed to assist in the development of Java based LTI 
 
 ### Build
 
-[![Build Status](https://travis-ci.org/ox-it/lti-launch.svg?branch=master)](https://travis-ci.org/ox-it/lti-launch)
+[![Build Status](https://travis-ci.org/oxctl/lti-launch.svg?branch=master)](https://travis-ci.org/oxctl/lti-launch)
 
 ### Technologies Used
 - Java 8
@@ -14,7 +14,7 @@ LTI Launch is a project designed to assist in the development of Java based LTI 
 
 ### Set Up
 
-The best way to understand how to use this is to look at the sample application https://github.com/ox-it/lti-demo
+The best way to understand how to use this is to look at the sample application https://github.com/oxctl/lti-demo
 
 ### Usage
 

--- a/lti-launch-autoconfigure/pom.xml
+++ b/lti-launch-autoconfigure/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <artifactId>lti-launch</artifactId>
-        <groupId>uk.ac.ox.it.lti</groupId>
+        <groupId>uk.ac.ox.ctl.lti</groupId>
         <version>2.0.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
@@ -21,7 +21,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>uk.ac.ox.it.lti</groupId>
+            <groupId>uk.ac.ox.ctl.lti</groupId>
             <artifactId>lti-launch-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/lti-launch-core/pom.xml
+++ b/lti-launch-core/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>uk.ac.ox.it.lti</groupId>
+        <groupId>uk.ac.ox.ctl.lti</groupId>
         <artifactId>lti-launch</artifactId>
         <version>2.0.0-SNAPSHOT</version>
         <relativePath>../</relativePath>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>uk.ac.ox.it.lti</groupId>
+    <groupId>uk.ac.ox.ctl.lti</groupId>
     <artifactId>lti-launch</artifactId>
     <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
@@ -21,7 +21,7 @@
 
     <name>LTI Launch</name>
     <description>Java framework for authenticating LTI launch requests from the Canvas LMS</description>
-    <url>https://github.com/ox-it/lti-launch</url>
+    <url>https://github.com/oxctl/lti-launch</url>
 
     <licenses>
         <license>
@@ -32,22 +32,22 @@
     </licenses>
 
     <organization>
-        <name>IT Services, University of Oxford</name>
-        <url>http://www.it.ox.ac.uk/</url>
+        <name>Centre for Teaching and Learning, University of Oxford</name>
+        <url>https://www.ctl.ox.ac.uk/</url>
     </organization>
 
     <developers>
         <developer>
             <name>Matthew Buckett</name>
-            <email>matthew.buckett@it.ox.ac.uk</email>
-            <organization>IT Services, University of Oxford</organization>
+            <email>matthew.buckett@ctl.ox.ac.uk</email>
+            <organization>Centre for Teaching and Learning, University of Oxford</organization>
         </developer>
     </developers>
 
     <scm>
-        <connection>scm:git:ssh://git@github.com/ox-it/lti-launch.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/ox-it/lti-launch.git</developerConnection>
-        <url>https://github.com/ox-it/lti-launch</url>
+        <connection>scm:git:ssh://git@github.com/oxctl/lti-launch.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/oxctl/lti-launch.git</developerConnection>
+        <url>https://github.com/oxctl/lti-launch</url>
         <tag>HEAD</tag>
     </scm>
 


### PR DESCRIPTION
With the Github repositories moving over to CTL the artifact IDs and the links should also update.